### PR TITLE
Support for stable rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Cargo.lock
 flamegraph.svg
 perf.out
 check.out
+target

--- a/check.sh
+++ b/check.sh
@@ -12,7 +12,9 @@ exec_prg() {
     do
         date; time cargo +nightly test --release -- --nocapture || exit $?
         date; time cargo +nightly test -- --nocapture || exit $?
-        # repeat this for stable, once package is ready for stable.
+        # repeat this for stable
+        date; time cargo test --release -- --nocapture || exit $?
+        date; time cargo test -- --nocapture || exit $?
     done
 }
 

--- a/src/cbor.rs
+++ b/src/cbor.rs
@@ -170,13 +170,13 @@ impl Cbor {
                 let n = encode_hdr(major, *info, w)?;
                 let m =
                     encode_addnl(err_at!(FailConvert, u64::try_from(byts.len()))?, w)?;
-                write_w!(w, &byts);
+                write_w!(w, byts);
                 n + m + byts.len()
             }
             Cbor::Major3(info, text) => {
                 let n = encode_hdr(major, *info, w)?;
                 let m = encode_addnl(err_at!(FailCbor, u64::try_from(text.len()))?, w)?;
-                write_w!(w, &text);
+                write_w!(w, text);
                 n + m + text.len()
             }
             Cbor::Major4(info, list) => {

--- a/src/cbor.rs
+++ b/src/cbor.rs
@@ -19,6 +19,7 @@ use std::{
     cmp,
     convert::{TryFrom, TryInto},
     ffi, io,
+    sync::Arc,
 };
 
 macro_rules! read_r {
@@ -49,6 +50,15 @@ pub trait IntoCbor {
 pub trait FromCbor: Sized {
     /// Convert value from [Cbor] into type's value.
     fn from_cbor(val: Cbor) -> Result<Self>;
+}
+
+impl<T> FromCbor for Arc<T>
+where
+    T: FromCbor,
+{
+    fn from_cbor(val: Cbor) -> Result<Self> {
+        T::from_cbor(val).map(Arc::new)
+    }
 }
 
 /// Recursion limit for nested Cbor objects.
@@ -604,6 +614,33 @@ impl arbitrary::Arbitrary for SimpleValue {
 
 impl Eq for SimpleValue {}
 
+/// Stub trait until `total_cmp` is stabilized
+/// implementations taken from
+/// https://github.com/l0calh05t/totally-ordered-rs/blob/be4e11c9c9edefd9763473fa3e3189dcee995bb5/src/lib.rs
+trait TotalCmpStub {
+    fn total_cmp_stub(&self, other: &Self) -> cmp::Ordering;
+}
+
+impl TotalCmpStub for f32 {
+    fn total_cmp_stub(&self, other: &Self) -> cmp::Ordering {
+        let mut a = self.to_bits() as i32;
+        let mut b = other.to_bits() as i32;
+        a ^= (((a >> (32 - 1)) as u32) >> 1) as i32;
+        b ^= (((b >> (32 - 1)) as u32) >> 1) as i32;
+        a.cmp(&b)
+    }
+}
+
+impl TotalCmpStub for f64 {
+    fn total_cmp_stub(&self, other: &Self) -> cmp::Ordering {
+        let mut a = self.to_bits() as i64;
+        let mut b = other.to_bits() as i64;
+        a ^= (((a >> (64 - 1)) as u64) >> 1) as i64;
+        b ^= (((b >> (64 - 1)) as u64) >> 1) as i64;
+        a.cmp(&b)
+    }
+}
+
 impl PartialEq for SimpleValue {
     fn eq(&self, other: &Self) -> bool {
         use SimpleValue::*;
@@ -616,8 +653,8 @@ impl PartialEq for SimpleValue {
             (Undefined, Undefined) => true,
             (Reserved24(a), Reserved24(b)) => a == b,
             (F16(a), F16(b)) => a == b,
-            (F32(a), F32(b)) => a.total_cmp(b) == cmp::Ordering::Equal,
-            (F64(a), F64(b)) => a.total_cmp(b) == cmp::Ordering::Equal,
+            (F32(a), F32(b)) => a.total_cmp_stub(b) == cmp::Ordering::Equal,
+            (F64(a), F64(b)) => a.total_cmp_stub(b) == cmp::Ordering::Equal,
             (Break, Break) => true,
             (_, _) => false,
         }
@@ -860,8 +897,8 @@ impl PartialEq for Key {
             (Bool(a), Bool(b)) => a == b,
             (N64(a), N64(b)) => a == b,
             (U64(a), U64(b)) => a == b,
-            (F32(a), F32(b)) => a.total_cmp(b) == cmp::Ordering::Equal,
-            (F64(a), F64(b)) => a.total_cmp(b) == cmp::Ordering::Equal,
+            (F32(a), F32(b)) => a.total_cmp_stub(b) == cmp::Ordering::Equal,
+            (F64(a), F64(b)) => a.total_cmp_stub(b) == cmp::Ordering::Equal,
             (Bytes(a), Bytes(b)) => a == b,
             (Text(a), Text(b)) => a == b,
             (_, _) => false,
@@ -883,8 +920,8 @@ impl Ord for Key {
                 (U64(_), N64(_)) => cmp::Ordering::Greater,
                 (Bytes(a), Bytes(b)) => a.cmp(b),
                 (Text(a), Text(b)) => a.cmp(b),
-                (F32(a), F32(b)) => a.total_cmp(b),
-                (F64(a), F64(b)) => a.total_cmp(b),
+                (F32(a), F32(b)) => a.total_cmp_stub(b),
+                (F64(a), F64(b)) => a.total_cmp_stub(b),
                 (_, _) => unreachable!(),
             }
         } else {
@@ -1031,6 +1068,20 @@ impl FromCbor for f64 {
         match val {
             Cbor::Major7(_, SimpleValue::F64(val)) => Ok(val),
             _ => err_at!(FailConvert, msg: "not f64"),
+        }
+    }
+}
+impl<T> IntoCbor for Arc<T>
+where
+    T: IntoCbor + Clone,
+{
+    fn into_cbor(self) -> Result<Cbor> {
+        match Arc::try_unwrap(self) {
+            Ok(s) => s.into_cbor(),
+            Err(s) => {
+                let s: T = s.as_ref().clone();
+                s.into_cbor()
+            }
         }
     }
 }

--- a/src/cbor_test.rs
+++ b/src/cbor_test.rs
@@ -32,7 +32,7 @@ fn test_simple_value() {
             (order, sval) => panic!("{} {:?}", order, sval),
         }
 
-        let val: Cbor = match (&sval, sval.clone().into_cbor()) {
+        let val: Cbor = match (&sval, sval.into_cbor()) {
             (Unassigned, Err(_)) => continue,
             (Undefined, Err(_)) => continue,
             (Reserved24(_), Err(_)) => continue,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 //! Package implement collection of tools and traits for building
 //! distributed applications.
 
-#![feature(total_cmp)]
 #![allow(clippy::many_single_char_names)]
 
 use std::{error, fmt, result};

--- a/src/xorfilter.rs
+++ b/src/xorfilter.rs
@@ -3,6 +3,7 @@ use xorfilter::Xor8;
 use std::{
     hash::{BuildHasher, Hash},
     result,
+    sync::Arc,
 };
 
 use crate::{
@@ -18,7 +19,7 @@ struct CborXor8 {
     hash_builder: Vec<u8>,
     seed: u64,
     block_length: u32,
-    finger_prints: Vec<u8>,
+    finger_prints: Arc<Vec<u8>>,
 }
 
 impl CborXor8 {

--- a/src/xorfilter_test.rs
+++ b/src/xorfilter_test.rs
@@ -15,7 +15,7 @@ fn test_basic7() {
     let filter = {
         let mut filter = Xor8::<BuildHasherDefault>::new();
         filter.populate(&keys);
-        filter.build();
+        filter.build().expect("failed to build filter");
         filter
     };
 


### PR DESCRIPTION
This inlines a stub for total_cmp to allow using stable rust with the crate. It also fixes a error with `Arc<T>` not implementing the cbor traits